### PR TITLE
Fix for events on 1.4.2

### DIFF
--- a/packages/cep47-client/package.json
+++ b/packages/cep47-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-cep47-js-client",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "> TODO: description",
   "author": "Jan Hoffmann <jan@casperlabs.io>",
   "homepage": "",

--- a/packages/cep47-client/src/cep47client.ts
+++ b/packages/cep47-client/src/cep47client.ts
@@ -70,6 +70,8 @@ class CEP47Client extends CasperContractClient {
   }
 
   public async setContractHash(hash: string) {
+    const lowercaseHash = hash.toLowerCase();
+
     const LIST_OF_NAMED_KEYS = [
       "balances",
       "metadata",
@@ -82,10 +84,10 @@ class CEP47Client extends CasperContractClient {
 
     const { contractPackageHash, namedKeys } = await setClient(
       this.nodeAddress,
-      hash,
+      lowercaseHash,
       LIST_OF_NAMED_KEYS
     );
-    this.contractHash = hash.toLowerCase();
+    this.contractHash = lowercaseHash;
     this.contractPackageHash = contractPackageHash.replace(
       "contract-package-wasm",
       ""

--- a/packages/cep47-client/src/cep47client.ts
+++ b/packages/cep47-client/src/cep47client.ts
@@ -70,8 +70,6 @@ class CEP47Client extends CasperContractClient {
   }
 
   public async setContractHash(hash: string) {
-    const lowercaseHash = hash.toLowerCase();
-
     const LIST_OF_NAMED_KEYS = [
       "balances",
       "metadata",
@@ -84,14 +82,14 @@ class CEP47Client extends CasperContractClient {
 
     const { contractPackageHash, namedKeys } = await setClient(
       this.nodeAddress,
-      lowercaseHash,
+      hash,
       LIST_OF_NAMED_KEYS
     );
-    this.contractHash = lowercaseHash;
+    this.contractHash = hash;
     this.contractPackageHash = contractPackageHash.replace(
       "contract-package-wasm",
       ""
-    ).toLowerCase();
+    );
     /* @ts-ignore */
     this.namedKeys = namedKeys;
   }

--- a/packages/cep47-client/src/cep47client.ts
+++ b/packages/cep47-client/src/cep47client.ts
@@ -85,11 +85,11 @@ class CEP47Client extends CasperContractClient {
       hash,
       LIST_OF_NAMED_KEYS
     );
-    this.contractHash = hash;
+    this.contractHash = hash.toLowerCase();
     this.contractPackageHash = contractPackageHash.replace(
       "contract-package-wasm",
       ""
-    );
+    ).toLowerCase();
     /* @ts-ignore */
     this.namedKeys = namedKeys;
   }

--- a/packages/client-helper/package.json
+++ b/packages/client-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-client-helper",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "> TODO: description",
   "author": "Jan Hoffmann <jan@casperlabs.io>",
   "homepage": "",

--- a/packages/client-helper/src/helpers/utils.ts
+++ b/packages/client-helper/src/helpers/utils.ts
@@ -158,7 +158,7 @@ export const parseEvent = (
               const event = clValue.get(CLValueBuilder.string("event_type"));
               if (
                 hash &&
-                hash.value() === contractPackageHash &&
+                hash.value().toLowerCase() === contractPackageHash &&
                 event &&
                 eventNames.includes(event.value())
               ) {

--- a/packages/client-helper/src/helpers/utils.ts
+++ b/packages/client-helper/src/helpers/utils.ts
@@ -158,7 +158,7 @@ export const parseEvent = (
               const event = clValue.get(CLValueBuilder.string("event_type"));
               if (
                 hash &&
-                hash.value().toLowerCase() === contractPackageHash &&
+                hash.value() === contractPackageHash.toLowerCase() &&
                 event &&
                 eventNames.includes(event.value())
               ) {

--- a/packages/client-helper/src/helpers/utils.ts
+++ b/packages/client-helper/src/helpers/utils.ts
@@ -158,6 +158,8 @@ export const parseEvent = (
               const event = clValue.get(CLValueBuilder.string("event_type"));
               if (
                 hash &&
+                // NOTE: Calling toLowerCase() because current JS-SDK doesn't support checksumed hashes and returns all lower case value
+                // Remove it after updating SDK
                 hash.value() === contractPackageHash.toLowerCase() &&
                 event &&
                 eventNames.includes(event.value())

--- a/packages/erc20-client/package.json
+++ b/packages/erc20-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-erc20-js-client",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "> TODO: description",
   "author": "Jan Hoffmann <jan@casperlabs.io>",
   "homepage": "",


### PR DESCRIPTION
The problem was that we do comparison of the event emitted
contract-package-hash and the one taken from contract named keys.
The first one is all-lowercase as its converted by JS-SDK which doesn't
support checksumed keys and the second one is provided as a string so it
can have mixed case value.
Now we call `toLowerCase()` on `contract-package-hash` when client starts so
it matches values returned from js-sdk.
